### PR TITLE
#22_ErrorHandling_Validation

### DIFF
--- a/backend/app/api/architectures.py
+++ b/backend/app/api/architectures.py
@@ -3,7 +3,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session, selectinload
 
 from app.database import get_db
@@ -26,6 +26,20 @@ _ARCH_LOAD_OPTIONS = [
 ]
 
 
+def _integrity_error_detail(exc: IntegrityError) -> str:
+    """Return a human-readable constraint violation message from an IntegrityError."""
+    msg = str(exc.orig).lower() if exc.orig else str(exc).lower()
+    if "unique" in msg or "duplicate" in msg:
+        return "A record with these values already exists (unique constraint violation)."
+    if "not null" in msg or "null value" in msg or "notnull" in msg:
+        return "A required field is missing (not-null constraint violation)."
+    if "foreign key" in msg or "foreignkey" in msg:
+        return "Referenced record does not exist (foreign key constraint violation)."
+    if "check" in msg:
+        return "A field value is out of the allowed range (check constraint violation)."
+    return "Database constraint violation."
+
+
 @router.post(
     "",
     response_model=ArchitectureResponse,
@@ -44,7 +58,7 @@ def create_architecture(
     component_ids = [c.component_id for c in payload.components]
     if len(component_ids) != len(set(component_ids)):
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Duplicate component_id values in request.",
         )
 
@@ -52,12 +66,12 @@ def create_architecture(
     for flow in payload.flows:
         if flow.source_component_id not in component_id_set:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=f"Flow source_component_id '{flow.source_component_id}' not found in components.",
             )
         if flow.target_component_id not in component_id_set:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=f"Flow target_component_id '{flow.target_component_id}' not found in components.",
             )
 
@@ -102,6 +116,15 @@ def create_architecture(
         db.refresh(arch)
         logger.info("Architecture created: id=%d name='%s'", arch.id, arch.name)
         return ArchitectureResponse.model_validate(arch)
+
+    except IntegrityError as exc:
+        db.rollback()
+        detail = _integrity_error_detail(exc)
+        logger.warning("Constraint violation creating architecture: %s", exc.orig)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=detail,
+        ) from exc
 
     except SQLAlchemyError as exc:
         db.rollback()

--- a/backend/app/core/main.py
+++ b/backend/app/core/main.py
@@ -4,8 +4,10 @@ import logging
 from contextlib import asynccontextmanager
 from typing import List
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.core.config import get_settings
 from app.database import check_connection, init_db
@@ -47,6 +49,24 @@ app.add_middleware(
 )
 
 app.include_router(architectures_router)
+
+
+@app.exception_handler(SQLAlchemyError)
+async def sqlalchemy_exception_handler(request: Request, exc: SQLAlchemyError):
+    logger.error("Unhandled database error on %s %s: %s", request.method, request.url.path, exc)
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "An unexpected database error occurred."},
+    )
+
+
+@app.exception_handler(Exception)
+async def generic_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "An unexpected internal server error occurred."},
+    )
 
 
 @app.get("/health")

--- a/backend/tests/test_error_handling.py
+++ b/backend/tests/test_error_handling.py
@@ -1,0 +1,425 @@
+"""
+tests/test_error_handling.py
+
+Unit tests for database error handling in the architectures API.
+
+Tests cover:
+    - 422 validation errors (duplicate component_id, unknown flow references,
+      missing required fields) — no DB interaction needed
+    - 409 Conflict on IntegrityError (unique / not-null / FK constraint violations)
+    - 500 Internal Server Error on generic SQLAlchemyError
+    - Rollback is called exactly once on every DB failure path
+    - 404 for a missing architecture id
+    - _integrity_error_detail helper message classification
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError, OperationalError, SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.api.architectures import _integrity_error_detail
+from app.core.main import app
+from app.database import get_db
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_PAYLOAD: dict = {
+    "name": "Test Architecture",
+    "components": [],
+    "flows": [],
+}
+
+WITH_COMPONENTS: dict = {
+    "name": "Arch With Components",
+    "components": [
+        {"component_id": "c1", "name": "Sensor", "component_type": "Sensor"},
+        {"component_id": "c2", "name": "Compute", "component_type": "Compute"},
+    ],
+    "flows": [
+        {"source_component_id": "c1", "target_component_id": "c2"},
+    ],
+}
+
+
+def _mock_db(*, flush_exc=None, commit_exc=None) -> MagicMock:
+    """Return a MagicMock Session with optional side-effects on flush/commit."""
+    db = MagicMock(spec=Session)
+    if flush_exc is not None:
+        db.flush.side_effect = flush_exc
+    if commit_exc is not None:
+        db.commit.side_effect = commit_exc
+    return db
+
+
+def _override(mock_session: MagicMock):
+    """Build a get_db override that yields the given mock session."""
+    def _get_db_override():
+        yield mock_session
+    return _get_db_override
+
+
+def _make_integrity_error(message: str = "UNIQUE constraint failed") -> IntegrityError:
+    orig = Exception(message)
+    return IntegrityError("INSERT INTO architectures", {}, orig)
+
+
+def _make_sqlalchemy_error() -> SQLAlchemyError:
+    return OperationalError("SELECT 1", {}, Exception("connection refused"))
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# _integrity_error_detail helper
+# ---------------------------------------------------------------------------
+
+class TestIntegrityErrorDetail:
+
+    def test_unique_constraint_message(self):
+        exc = _make_integrity_error("UNIQUE constraint failed: architectures.name")
+        assert "unique constraint" in _integrity_error_detail(exc).lower()
+
+    def test_duplicate_entry_message(self):
+        exc = _make_integrity_error("duplicate key value violates unique constraint")
+        assert "already exists" in _integrity_error_detail(exc).lower()
+
+    def test_not_null_constraint_message(self):
+        exc = _make_integrity_error("null value in column violates not-null constraint")
+        assert "required field" in _integrity_error_detail(exc).lower()
+
+    def test_notnull_sqlite_style(self):
+        exc = _make_integrity_error("NOT NULL constraint failed: components.name")
+        assert "required field" in _integrity_error_detail(exc).lower()
+
+    def test_foreign_key_constraint_message(self):
+        exc = _make_integrity_error("foreign key constraint fails")
+        assert "does not exist" in _integrity_error_detail(exc).lower()
+
+    def test_check_constraint_message(self):
+        exc = _make_integrity_error("check constraint violated")
+        assert "range" in _integrity_error_detail(exc).lower()
+
+    def test_unknown_constraint_returns_generic(self):
+        exc = _make_integrity_error("some obscure db error xyz")
+        assert "constraint violation" in _integrity_error_detail(exc).lower()
+
+    def test_none_orig_does_not_crash(self):
+        exc = IntegrityError("stmt", {}, None)
+        result = _integrity_error_detail(exc)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Validation errors (422) — no DB interaction
+# ---------------------------------------------------------------------------
+
+class TestValidationErrors:
+
+    def test_missing_name_returns_422(self, client):
+        r = client.post("/architectures", json={"components": [], "flows": []})
+        assert r.status_code == 422
+
+    def test_duplicate_component_id_returns_422(self, client):
+        payload = {
+            "name": "Dup Test",
+            "components": [
+                {"component_id": "same", "name": "A", "component_type": "Sensor"},
+                {"component_id": "same", "name": "B", "component_type": "Compute"},
+            ],
+            "flows": [],
+        }
+        r = client.post("/architectures", json=payload)
+        assert r.status_code == 422
+        assert "Duplicate" in r.json()["detail"]
+
+    def test_flow_source_not_in_components_returns_422(self, client):
+        payload = {
+            "name": "Bad Flow",
+            "components": [
+                {"component_id": "c1", "name": "A", "component_type": "Sensor"},
+            ],
+            "flows": [{"source_component_id": "GHOST", "target_component_id": "c1"}],
+        }
+        r = client.post("/architectures", json=payload)
+        assert r.status_code == 422
+        assert "GHOST" in r.json()["detail"]
+
+    def test_flow_target_not_in_components_returns_422(self, client):
+        payload = {
+            "name": "Bad Flow Target",
+            "components": [
+                {"component_id": "c1", "name": "A", "component_type": "Sensor"},
+            ],
+            "flows": [{"source_component_id": "c1", "target_component_id": "GHOST"}],
+        }
+        r = client.post("/architectures", json=payload)
+        assert r.status_code == 422
+        assert "GHOST" in r.json()["detail"]
+
+    def test_criticality_below_minimum_returns_422(self, client):
+        payload = {
+            "name": "Bad Criticality",
+            "components": [
+                {"component_id": "c1", "name": "A", "component_type": "Sensor", "criticality": 0},
+            ],
+            "flows": [],
+        }
+        r = client.post("/architectures", json=payload)
+        assert r.status_code == 422
+
+    def test_criticality_above_maximum_returns_422(self, client):
+        payload = {
+            "name": "Bad Criticality High",
+            "components": [
+                {"component_id": "c1", "name": "A", "component_type": "Sensor", "criticality": 11},
+            ],
+            "flows": [],
+        }
+        r = client.post("/architectures", json=payload)
+        assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# IntegrityError → 409
+# ---------------------------------------------------------------------------
+
+class TestIntegrityErrorHandling:
+
+    def test_unique_violation_returns_409(self, client):
+        db = _mock_db(flush_exc=_make_integrity_error("UNIQUE constraint failed"))
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.post("/architectures", json=MINIMAL_PAYLOAD)
+            assert r.status_code == 409
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_409_detail_is_human_readable(self, client):
+        db = _mock_db(flush_exc=_make_integrity_error("UNIQUE constraint failed"))
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.post("/architectures", json=MINIMAL_PAYLOAD)
+            detail = r.json()["detail"]
+            assert isinstance(detail, str)
+            assert len(detail) > 10
+            assert detail != "Internal Server Error"
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_not_null_violation_returns_409(self, client):
+        db = _mock_db(flush_exc=_make_integrity_error("null value in column violates not-null constraint"))
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.post("/architectures", json=MINIMAL_PAYLOAD)
+            assert r.status_code == 409
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_foreign_key_violation_returns_409(self, client):
+        db = _mock_db(flush_exc=_make_integrity_error("foreign key constraint fails"))
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.post("/architectures", json=MINIMAL_PAYLOAD)
+            assert r.status_code == 409
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_rollback_called_on_integrity_error(self, client):
+        db = _mock_db(flush_exc=_make_integrity_error("UNIQUE constraint failed"))
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            client.post("/architectures", json=MINIMAL_PAYLOAD)
+            db.rollback.assert_called_once()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_commit_not_called_on_integrity_error(self, client):
+        db = _mock_db(flush_exc=_make_integrity_error("UNIQUE constraint failed"))
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            client.post("/architectures", json=MINIMAL_PAYLOAD)
+            db.commit.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_integrity_error_on_commit_also_returns_409(self, client):
+        # Integrity errors can surface at commit time too (deferred constraints).
+        db = _mock_db(commit_exc=_make_integrity_error("UNIQUE constraint failed"))
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.post("/architectures", json=MINIMAL_PAYLOAD)
+            assert r.status_code == 409
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+
+# ---------------------------------------------------------------------------
+# SQLAlchemyError → 500
+# ---------------------------------------------------------------------------
+
+class TestSQLAlchemyErrorHandling:
+
+    def test_db_error_on_flush_returns_500(self, client):
+        db = _mock_db(flush_exc=_make_sqlalchemy_error())
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.post("/architectures", json=MINIMAL_PAYLOAD)
+            assert r.status_code == 500
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_db_error_on_commit_returns_500(self, client):
+        db = _mock_db(commit_exc=_make_sqlalchemy_error())
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.post("/architectures", json=MINIMAL_PAYLOAD)
+            assert r.status_code == 500
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_500_detail_is_meaningful(self, client):
+        db = _mock_db(flush_exc=_make_sqlalchemy_error())
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.post("/architectures", json=MINIMAL_PAYLOAD)
+            detail = r.json()["detail"]
+            assert "database" in detail.lower() or "failed" in detail.lower()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_rollback_called_on_sqlalchemy_error(self, client):
+        db = _mock_db(flush_exc=_make_sqlalchemy_error())
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            client.post("/architectures", json=MINIMAL_PAYLOAD)
+            db.rollback.assert_called_once()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_commit_not_called_on_sqlalchemy_error(self, client):
+        db = _mock_db(flush_exc=_make_sqlalchemy_error())
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            client.post("/architectures", json=MINIMAL_PAYLOAD)
+            db.commit.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_list_endpoint_db_error_returns_500(self, client):
+        db = MagicMock(spec=Session)
+        db.query.side_effect = _make_sqlalchemy_error()
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.get("/architectures")
+            assert r.status_code == 500
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_get_by_id_endpoint_db_error_returns_500(self, client):
+        db = MagicMock(spec=Session)
+        db.query.side_effect = _make_sqlalchemy_error()
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.get("/architectures/1")
+            assert r.status_code == 500
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+
+# ---------------------------------------------------------------------------
+# 404 — missing architecture
+# ---------------------------------------------------------------------------
+
+class TestNotFound:
+
+    def test_get_nonexistent_id_returns_404(self, client):
+        db = MagicMock(spec=Session)
+        # Simulate query chain: .query().options().filter().first() -> None
+        db.query.return_value.options.return_value.filter.return_value.first.return_value = None
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.get("/architectures/99999")
+            assert r.status_code == 404
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_404_detail_includes_id(self, client):
+        db = MagicMock(spec=Session)
+        db.query.return_value.options.return_value.filter.return_value.first.return_value = None
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.get("/architectures/42")
+            assert "42" in r.json()["detail"]
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_list_empty_returns_200_not_404(self, client):
+        db = MagicMock(spec=Session)
+        db.query.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = []
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            r = client.get("/architectures")
+            assert r.status_code == 200
+            assert r.json() == []
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+
+# ---------------------------------------------------------------------------
+# Rollback isolation — verify rollback doesn't bleed across tests
+# ---------------------------------------------------------------------------
+
+class TestRollbackBehaviour:
+
+    def test_rollback_called_exactly_once_per_integrity_error(self, client):
+        db = _mock_db(flush_exc=_make_integrity_error("UNIQUE constraint failed"))
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            client.post("/architectures", json=MINIMAL_PAYLOAD)
+            assert db.rollback.call_count == 1
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_rollback_called_exactly_once_per_sqlalchemy_error(self, client):
+        db = _mock_db(flush_exc=_make_sqlalchemy_error())
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            client.post("/architectures", json=MINIMAL_PAYLOAD)
+            assert db.rollback.call_count == 1
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    def test_successful_path_does_not_call_rollback(self, client):
+        db = MagicMock(spec=Session)
+        # Make flush work (no side effect), query chain returns a mock arch.
+        mock_arch = MagicMock()
+        mock_arch.id = 1
+        mock_arch.name = "Test"
+        mock_arch.description = None
+        mock_arch.properties = {}
+        mock_arch.components = []
+        mock_arch.flows = []
+        # flush populates arch.id — simulate by setting it on mock results
+        db.flush.side_effect = None
+        db.commit.side_effect = None
+        db.refresh.side_effect = None
+        app.dependency_overrides[get_db] = _override(db)
+        try:
+            # We don't care if this returns 200 or 500 (serialisation will fail
+            # since the mock arch isn't a real ORM object) — we only care that
+            # rollback was NOT triggered by the flush/commit path.
+            client.post("/architectures", json=MINIMAL_PAYLOAD)
+            db.rollback.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
feat(api): robust error handling with IntegrityError, rollback, and global handlers

- IntegrityError → 409 Conflict with human-readable constraint message
- _integrity_error_detail() classifies unique/not-null/FK/check violations
- SQLAlchemyError → 500, rollback always called before raising
- Global exception handlers in main.py for SQLAlchemyError and Exception
- Updated 422 status constant to HTTP_422_UNPROCESSABLE_CONTENT
- 34 unit tests: validation errors, constraint violations, rollback behavior, 404, and empty-list edge cases; all mock-based (no DB needed)